### PR TITLE
部品名のリンク化

### DIFF
--- a/app/views/parts/calculate.html.erb
+++ b/app/views/parts/calculate.html.erb
@@ -6,7 +6,7 @@
   <%# 必要な部品の表示 %>
   <div class="need-table-area">
     <% if @parts == {} %>
-      <p>「<%= link_to @part.name, part_path(@part) %>」に必要な部品はありません</p>
+      <p>「<%= link_to @part.name, part_path(@part) %>」に外注部品はありません</p>
     <% else %>
       <div class="need-table-title">「<%= link_to @part.name, part_path(@part) %>」の作成に必要な<span>部品</span>一覧</div>
       <div class="need-table">

--- a/app/views/parts/new.html.erb
+++ b/app/views/parts/new.html.erb
@@ -55,7 +55,10 @@
     <tbody id="parts-history-data">
       <% @parts.each do |part| %>
         <tr>
-          <td><%= part.name %></td>
+          <td>
+            <%= link_to "#{part.name}", part_path(part) %>
+            <%#= part.name %>
+          </td>
           <td class="history-stock"><%= part.stock %></td>
           <% if part.finished? %>
             <td>完成品</td>

--- a/app/views/parts/new.html.erb
+++ b/app/views/parts/new.html.erb
@@ -57,7 +57,6 @@
         <tr>
           <td>
             <%= link_to "#{part.name}", part_path(part) %>
-            <%#= part.name %>
           </td>
           <td class="history-stock"><%= part.stock %></td>
           <% if part.finished? %>

--- a/app/views/parts/show.html.erb
+++ b/app/views/parts/show.html.erb
@@ -86,7 +86,9 @@
           <tbody id="parts-history-data">
             <% @part.children.each do |child| %>
               <tr>
-                <td><%= child.name %></td>
+                <td>
+                  <%= link_to "#{child.name}", part_path(child) %>
+                </td>
                 <td class="history-stock"><%= PartsRelation.find_by(parent_id: @part.id, child_id: child.id).necessary_nums %></td>
                 <td class="no-border">
                   <div class="button-link__history">

--- a/app/views/parts_relations/new.html.erb
+++ b/app/views/parts_relations/new.html.erb
@@ -48,8 +48,21 @@
         <% part_p = Part.find(parts_relation.parent_id) %>
         <% part_c = Part.find(parts_relation.child_id) %>
         <tr>
-          <td><%= part_p.name %></td>
-          <td><%= part_c.name %></td>
+          <%# @partと同じものはリンク化しない %>
+          <td>
+            <% if part_p == @part %>
+              <%= part_p.name %>
+            <% else %>
+              <%= link_to "#{part_p.name}", part_path(part_p) %>
+            <% end %>
+          </td>
+          <td>
+            <% if part_c == @part %>
+              <%= part_c.name %>
+            <% else %>
+              <%= link_to "#{part_c.name}", part_path(part_c) %>
+            <% end %>
+          </td>
           <td><%= parts_relation.necessary_nums %></td>
           <td><%= l parts_relation.created_at %></td>
         </tr>


### PR DESCRIPTION
# What
部品名のリンク化

# Why
部品名をリンク化することで、部品から部品への遷移が容易になるため